### PR TITLE
added define-lang macro, tests, readme.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,51 @@
 # Inline-Lang
 
 ## Usage
+TO use inline reader.
+```common-lisp
+(inline-lang:enable-inline-reader)
+;=> t
+
+##foo "bar" baz##
+;=> "foo \"bar\" baz"
+
+```
+
+To use node.js commands.
+```common-lisp
+(inline-lang:enable-inline-reader)
+;=> t
+
+(inline-lang:node
+##
+var http = require('http');
+http.createServer(function (req, res) {
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end('Hello World\n');
+}).listen(3000);
+
+console.log('Server running at http://localhost:3000/');
+##)
+
+
+```
+TO access your local host. (http://localhost:3000).
+
 
 ## Installation
+
+1. Clone to your local-projects.
+```common-lisp
+cd $HOME/quicklisp/local-projects
+git clone https://github.com/libgirlenterprise/inline-lang.git
+
+```
+
+2. Start your lisp. Then, jsut:
+```common-lisp
+(ql:quickload :cl-webcam)
+
+```
 
 ## Author
 

--- a/src/inline-lang.lisp
+++ b/src/inline-lang.lisp
@@ -2,6 +2,7 @@
   (:use :cl)
   (:export #:enable-inline-reader
 	   #:disable-inline-reader
+	   #:define-lang
 	   #:node))
 (in-package :inline-lang)
 
@@ -25,8 +26,12 @@
 (defun disable-inline-reader ()
   (setf *readtable* (pop *previous-readtables*)))
 
-(defun node (code-str)
-  (let ((code-stream (make-string-input-stream code-str)))
-    (uiop:run-program "node"
-		      :input code-stream
-		      :output *standard-output*)))
+(defmacro define-lang (name program-str)
+  (let ((gcode-str (gensym "code-str")))
+    `(defun ,name (,gcode-str)
+       (let ((code-stream (make-string-input-stream ,gcode-str)))
+	 (uiop:run-program ,program-str
+			   :input code-stream
+			   :output *standard-output*)))))
+
+(define-lang node "node")

--- a/tests/inline-lang.lisp
+++ b/tests/inline-lang.lisp
@@ -6,8 +6,15 @@
 
 ;; NOTE: To run this test file, execute `(asdf:test-system :inline-lang)' in your Lisp.
 
+(setf *enable-colors* nil)
+
 (plan nil)
 
-;; blah blah blah.
+(enable-inline-reader)
+
+(subtest "inline-reader test"
+  (is ##foo "bar" baz## "foo \"bar\" baz"))
+
+(disable-inline-reader)
 
 (finalize)


### PR DESCRIPTION
I added `define-lang` macro, tests, README.markdown.
`define-lang` macro is for use customize design.
Please merge it if you like.